### PR TITLE
Upgrade Spring Boot to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.8</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -17,7 +17,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
-        <testcontainers.version>1.21.1</testcontainers.version>
+        <testcontainers.version>2.0.2</testcontainers.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <spotless.version>2.43.0</spotless.version>
     </properties>
@@ -83,24 +83,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 </project>


### PR DESCRIPTION
- Update Spring Boot from 3.5.4 to 3.5.8 (latest stable release)
- Update Testcontainers from 1.21.1 to 2.0.2 (latest version)
- Remove spring-milestones repository as it's not needed for GA releases

Spring Boot 3.5.8 includes important fixes including Testcontainers compatibility with modern Docker versions.