### PR TITLE
Fix issue #7

### DIFF
--- a/aot/build-test-aot-native/build.gradle
+++ b/aot/build-test-aot-native/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.0.6'
+	id 'org.springframework.boot' version '4.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'org.graalvm.buildtools.native' version '0.9.20'
 	id 'io.spring.build.runtimehints-agent'
@@ -12,8 +12,6 @@ sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()
-	maven { url = 'https://repo.spring.io/milestone' }
-	maven { url = 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {

--- a/aot/quotes-native/build.gradle
+++ b/aot/quotes-native/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '3.0.6'
+	id 'org.springframework.boot' version '4.0.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'org.graalvm.buildtools.native' version '0.9.20'
 	id 'java'
@@ -10,14 +10,12 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 repositories {
-	maven { url 'https://repo.spring.io/milestone' }
 	mavenCentral()
-	maven { url 'https://repo.spring.io/snapshot' }
 }
 
 ext {
-	set('springCloudVersion', "2022.0.2")
-	set('testcontainersVersion', "1.18.0")
+	set('springCloudVersion', "2025.0.0")
+	set('testcontainersVersion', "1.21.1")
 }
 
 dependencies {

--- a/api/json-jackson/src/main/java/com/example/JacksonConfig.java
+++ b/api/json-jackson/src/main/java/com/example/JacksonConfig.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.autoconfigure.jackson.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,7 +18,7 @@ public class JacksonConfig {
    * Boot will automatically pick this bean and apply the changes during startup.
    */
   @Bean
-  public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+  public JsonMapperBuilderCustomizer jacksonCustomizer() {
     return builder -> {
       // Enable pretty printing (useful for dev/debug output)
       builder.indentOutput(true);

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.4</version>
+        <version>4.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -82,25 +82,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-milestones</id>
-            <name>Spring Milestones</name>
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/web/graphql/quotes-graphql/src/test/java/com/example/GraphQLDemoApplicationTests.java
+++ b/web/graphql/quotes-graphql/src/test/java/com/example/GraphQLDemoApplicationTests.java
@@ -6,6 +6,7 @@ import com.example.model.Author;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContext;
@@ -14,6 +15,7 @@ import org.springframework.graphql.test.tester.HttpGraphQlTester;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureWebTestClient
 class GraphQLDemoApplicationTests {
 
   @LocalServerPort private Integer port;


### PR DESCRIPTION
This commit upgrades the project from Spring Boot 3.5.4 to 4.0.0, applying necessary migration changes per the Spring Boot 4.0 Migration Guide.

Changes made:
- Updated Spring Boot version to 4.0.0 in root pom.xml
- Updated Spring Boot version to 4.0.0 in Gradle build files
- Updated Spring Cloud version to 2025.0.0 in Gradle files
- Updated Testcontainers version to 1.21.1 in Gradle files
- Migrated Jackson configuration from Jackson2ObjectMapperBuilderCustomizer to JsonMapperBuilderCustomizer (Jackson 3 compatibility)
- Added @AutoConfigureWebTestClient annotation to GraphQL test (required for WebTestClient auto-configuration in Spring Boot 4.0)

These changes align with the breaking changes documented in: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide

Resolves #7